### PR TITLE
#171994565 Enable search feature of items

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -19,7 +19,7 @@ app.use('/api/v1/items', routes);
 app.use('/api/v1/users', emailAuthRoutes);
 app.use('/api/v1/users/auth', socialAuthRoutes);
 app.use('/api/v1/users/profile', profileRouter);
-app.use('/api/v1/items/search', searchRouter)
+app.use('/api/v1/items/search', searchRouter);
 
 app.use('*', (req, res) =>
   // eslint-disable-next-line implicit-arrow-linebreak

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ import routes from './routes/lostItems/lostItem.route';
 import socialAuthRoutes from './routes/socialAuth/googleAuth';
 import emailAuthRoutes from './routes/authentication/auth';
 import profileRouter from './routes/profile';
+import searchRouter from './routes/searchDoc/search';
 
 const app = express();
 app.use(express.json());
@@ -18,6 +19,7 @@ app.use('/api/v1/items', routes);
 app.use('/api/v1/users', emailAuthRoutes);
 app.use('/api/v1/users/auth', socialAuthRoutes);
 app.use('/api/v1/users/profile', profileRouter);
+app.use('/api/v1/search', searchRouter)
 
 app.use('*', (req, res) =>
   // eslint-disable-next-line implicit-arrow-linebreak

--- a/src/app.js
+++ b/src/app.js
@@ -19,7 +19,7 @@ app.use('/api/v1/items', routes);
 app.use('/api/v1/users', emailAuthRoutes);
 app.use('/api/v1/users/auth', socialAuthRoutes);
 app.use('/api/v1/users/profile', profileRouter);
-app.use('/api/v1/search', searchRouter)
+app.use('/api/v1/items/search', searchRouter)
 
 app.use('*', (req, res) =>
   // eslint-disable-next-line implicit-arrow-linebreak

--- a/src/controllers/searchDoc/searchFoundItem.js
+++ b/src/controllers/searchDoc/searchFoundItem.js
@@ -1,5 +1,6 @@
 import Document from '../../models/lost';
 
+
 class SearchController{
     static async searchFoundItem(req, res){
         try{

--- a/src/controllers/searchDoc/searchFoundItem.js
+++ b/src/controllers/searchDoc/searchFoundItem.js
@@ -1,37 +1,37 @@
 import Document from '../../models/lost';
 
-class SearchController{
-    static async searchFoundItem(req, res){
-        try{
-            const foundDocs = await Document.find({
-               $and:[
-                {documentName: req.body.documentName},
-                {'status.isFound':true}
-            ]
-            });
-            if(foundDocs.length === 0) return res.status(400).json({msg:'No such document in database'});
+class SearchController {
+  static async searchFoundItem(req, res) {
+    try {
+      const foundDocs = await Document.find({
+        $and: [
+          { documentName: req.body.documentName },
+          { 'status.isFound': true }
+        ]
+      });
+      if (foundDocs.length === 0) return res.status(400).json({ msg: 'No such document in database' });
 
-            return res.status(200).send({foundDocs})
-        }catch(err){
-            return res.status(400).send({error: err.message});
-        }
-    };
-
-    static async searchLostItem(req, res){
-        try{
-            const lostDocs = await Document.find({
-               $and:[
-                {documentName: req.body.documentName},
-                {'status.isLost': true}
-            ]
-            });
-            if(lostDocs.length === 0) return res.status(400).json({msg:'No such document in database'});
-
-            return res.status(200).send({lostDocs})
-        }catch(err){
-            return res.status(400).send({error: err.message});
-        } 
+      return res.status(200).send({ foundDocs });
+    } catch (err) {
+      return res.status(400).send({ error: err.message });
     }
-};
+  }
+
+  static async searchLostItem(req, res) {
+    try {
+      const lostDocs = await Document.find({
+        $and: [
+          { documentName: req.body.documentName },
+          { 'status.isLost': true }
+        ]
+      });
+      if (lostDocs.length === 0) return res.status(400).json({ msg: 'No such document in database' });
+
+      return res.status(200).send({ lostDocs });
+    } catch (err) {
+      return res.status(400).send({ error: err.message });
+    }
+  }
+}
 
 export default SearchController;

--- a/src/controllers/searchDoc/searchFoundItem.js
+++ b/src/controllers/searchDoc/searchFoundItem.js
@@ -1,6 +1,5 @@
 import Document from '../../models/lost';
 
-
 class SearchController{
     static async searchFoundItem(req, res){
         try{

--- a/src/controllers/searchDoc/searchFoundItem.js
+++ b/src/controllers/searchDoc/searchFoundItem.js
@@ -32,6 +32,6 @@ class SearchController{
             return res.status(400).send({error: err.message});
         } 
     }
-}
+};
 
 export default SearchController;

--- a/src/controllers/searchDoc/searchFoundItem.js
+++ b/src/controllers/searchDoc/searchFoundItem.js
@@ -1,0 +1,37 @@
+import Document from '../../models/lost';
+
+class SearchController{
+    static async searchFoundItem(req, res){
+        try{
+            const foundDocs = await Document.find({
+               $and:[
+                {documentName: req.body.documentName},
+                {'status.isFound':true}
+            ]
+            });
+            if(foundDocs.length === 0) return res.status(400).json({msg:'No such document in database'});
+
+            return res.status(200).send({foundDocs})
+        }catch(err){
+            return res.status(400).send({error: err.message});
+        }
+    };
+
+    static async searchLostItem(req, res){
+        try{
+            const lostDocs = await Document.find({
+               $and:[
+                {documentName: req.body.documentName},
+                {'status.isLost': true}
+            ]
+            });
+            if(lostDocs.length === 0) return res.status(400).json({msg:'No such document in database'});
+
+            return res.status(200).send({lostDocs})
+        }catch(err){
+            return res.status(400).send({error: err.message});
+        } 
+    }
+}
+
+export default SearchController;

--- a/src/routes/searchDoc/search.js
+++ b/src/routes/searchDoc/search.js
@@ -6,8 +6,8 @@ import authentication from '../../middlewares/authentication';
 const searchRouter = new Router();
 
 searchRouter
-.post('/lost', authentication, SearchController.searchLostItem)
-.post('/found', authentication, SearchController.searchFoundItem);
+  .post('/lost', authentication, SearchController.searchLostItem)
+  .post('/found', authentication, SearchController.searchFoundItem);
 
 
 export default searchRouter;

--- a/src/routes/searchDoc/search.js
+++ b/src/routes/searchDoc/search.js
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import SearchController from '../../controllers/searchDoc/searchFoundItem';
+import authentication from '../../middlewares/authentication';
+
+
+const searchRouter = new Router();
+
+searchRouter
+.post('/lost', authentication, SearchController.searchLostItem)
+.post('/found', authentication, SearchController.searchFoundItem);
+
+
+export default searchRouter;


### PR DESCRIPTION
### **What does this PR do?**
Integrating search feature for both lost and found items

### **Description of task to be completed**

- Setting a search feature to retrieve documents from database

### **How should this be tested manually?**

- Clone the repo `git clone`

- Checkout the repo `git checkout ft-search-items-#171994565`

- Run `npm install` to install all dependencies

- Then run `npm run dev` to start the server

- In postman send a post request on `http://localhost:3000/api/v1/items/search/found` or `http://localhost:3000/api/v1/items/search/lost` to get found or lost document respectively, the data to send
`
{
"documentName":"docName"
}
`

- The you should see the returned document with the respective status of document if it is lost or found 

### **Any background context you want to provide?**

- In order to send a post request, user must login or signup if not have account and provide token generated to the header. By assigning key to `auth-token` and generated token in `value` of header.

### **What are the relevant pivotal tracker stories?**

- #171994565

