### PR TITLE
#174038985 Enable read lost/found items from DB

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,13 @@
 {
-    "presets": [
-      ["@babel/preset-env", {
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
         "useBuiltIns": false
-      }]
-    ],
-    "plugins": [
-      "@babel/plugin-transform-runtime"
+      }
     ]
-  }
+  ],
+  "plugins": [
+    "@babel/plugin-transform-runtime"
+  ]
+}

--- a/src/controllers/lostDoc/index.js
+++ b/src/controllers/lostDoc/index.js
@@ -1,5 +1,9 @@
-import lostItem from './lostItem';
 import foundItem from './foundItem';
+import lostItem from './lostItem';
 import deleteItem from './deleteItem';
+import { allLost, allFound } from '../lostDoc/readItem';
 
-export default { lostItem, foundItem, deleteItem};
+
+export default { lostItem, foundItem, deleteItem, allLost, allFound };
+
+

--- a/src/controllers/lostDoc/index.js
+++ b/src/controllers/lostDoc/index.js
@@ -1,9 +1,9 @@
 import foundItem from './foundItem';
 import lostItem from './lostItem';
 import deleteItem from './deleteItem';
-import { allLost, allFound } from '../lostDoc/readItem';
+import { allLost, allFound } from './readItem';
 
 
-export default { lostItem, foundItem, deleteItem, allLost, allFound };
-
-
+export default {
+  lostItem, foundItem, deleteItem, allLost, allFound
+};

--- a/src/controllers/lostDoc/index.js
+++ b/src/controllers/lostDoc/index.js
@@ -1,4 +1,8 @@
 import lostItem from './lostItem';
 import foundItem from './foundItem';
+import { allLost, allFound } from '../lostDoc/readItem';
 
-export default { lostItem, foundItem };
+
+export default { lostItem, foundItem, allLost, allFound };
+
+

--- a/src/controllers/lostDoc/readItem.js
+++ b/src/controllers/lostDoc/readItem.js
@@ -1,0 +1,40 @@
+import ReadItem from '../../models/lost';
+
+export const allFound = async (req, res) => {
+    try{
+        const allFoundItems = await ReadItem.find({
+            'status.isFound': true
+        });
+        if(!allFoundItems) {
+          return res
+           .status(404)
+           .json({error: 'No found document registered yet'});
+        }
+
+        return res
+           .status(200)
+           .json({allFoundItems});
+    } catch(err) {
+        return res.status(500).json({error: err.message})
+    }
+}
+
+export const allLost = async (req, res) => {
+    try {
+        const allLostItems = await ReadItem.find({
+            'status.isLost': true
+        });
+        if(!allLostItems) {
+         return res
+            .status(404)
+            .json({error: 'No lost document registered yet'});
+        }
+
+
+         return res
+            .status(200)
+            .json({allLostItems});
+    } catch(err) {
+        return res.status(500).json({error: err.message})
+    }
+}

--- a/src/controllers/lostDoc/readItem.js
+++ b/src/controllers/lostDoc/readItem.js
@@ -1,0 +1,27 @@
+import ReadItem from '../../models/lost';
+
+export const allFound = async(req, res) =>{
+    try{
+        const allFoundItems = await ReadItem.find({
+            'status.isFound': true
+        });
+        if(!allFoundItems) return res.status(400).json({error: 'No found document in DB yet'});
+
+        return res.status(200).json({allFoundItems});
+    }catch(err){
+        return res.status(500).json({error: err.message})
+    }
+}
+
+export const allLost = async(req, res) =>{
+    try{
+        const allLostItems = await ReadItem.find({
+            'status.isLost': true
+        });
+        if(!allLostItems) return res.status(400).json({error: 'No document in DB yet'});
+
+        return res.status(200).json({allLostItems});
+    }catch(err){
+        return res.status(500).json({error: err.message})
+    }
+}

--- a/src/controllers/lostDoc/readItem.js
+++ b/src/controllers/lostDoc/readItem.js
@@ -1,40 +1,32 @@
 import ReadItem from '../../models/lost';
 
 export const allFound = async (req, res) => {
-    try{
-        const allFoundItems = await ReadItem.find({
-            'status.isFound': true
-        });
-        if(!allFoundItems) {
-          return res
-           .status(404)
-           .json({error: 'No found document registered yet'});
-        }
-
-        return res
-           .status(200)
-           .json({allFoundItems});
-    } catch(err) {
-        return res.status(500).json({error: err.message})
+  try {
+    const allFoundItems = await ReadItem.find({
+      'status.isFound': true
+    });
+    if (!allFoundItems) {
+      return res
+        .status(404)
+        .json({ error: 'No found document registered yet' });
     }
-}
 
+    return res.status(200).json({ allFoundItems });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+};
 export const allLost = async (req, res) => {
-    try {
-        const allLostItems = await ReadItem.find({
-            'status.isLost': true
-        });
-        if(!allLostItems) {
-         return res
-            .status(404)
-            .json({error: 'No lost document registered yet'});
-        }
-
-
-         return res
-            .status(200)
-            .json({allLostItems});
-    } catch(err) {
-        return res.status(500).json({error: err.message})
+  try {
+    const allLostItems = await ReadItem.find({
+      'status.isLost': true
+    });
+    if (!allLostItems) {
+      return res.status(404).json({ error: 'No lost document registered yet' });
     }
-}
+
+    return res.status(200).json({ allLostItems });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+};

--- a/src/routes/lostItems/lostItem.route.js
+++ b/src/routes/lostItems/lostItem.route.js
@@ -8,8 +8,7 @@ const lostRouter = express.Router();
 lostRouter
   .post('/lost', authentication, docValidation, lostItemsController.lostItem)
   .post('/found', authentication, docValidation, lostItemsController.foundItem)
-  .delete('/:_id', authentication, lostItemsController.deleteItem)
-  .get('/lost/all', authentication, lostItemsController.allLost)
-  .get('/found/all', authentication, lostItemsController.allFound);
+  .get('/lost', authentication, lostItemsController.allLost)
+  .get('/found', authentication, lostItemsController.allFound);
 
 export default lostRouter;

--- a/src/routes/lostItems/lostItem.route.js
+++ b/src/routes/lostItems/lostItem.route.js
@@ -8,6 +8,8 @@ const lostRouter = express.Router();
 lostRouter
   .post('/lost', authentication, docValidation, lostItemsController.lostItem)
   .post('/found', authentication, docValidation, lostItemsController.foundItem)
-  .delete('/:_id', authentication, lostItemsController.deleteItem);
+  .delete('/:_id', authentication, lostItemsController.deleteItem)
+  .get('/lost/all', authentication, lostItemsController.allLost)
+  .get('/found/all', authentication, lostItemsController.allFound);
 
 export default lostRouter;

--- a/src/routes/lostItems/lostItem.route.js
+++ b/src/routes/lostItems/lostItem.route.js
@@ -7,6 +7,8 @@ const lostRouter = express.Router();
 
 lostRouter
   .post('/lost', authentication, docValidation, lostItemsController.lostItem)
-  .post('/found', authentication, docValidation, lostItemsController.foundItem);
+  .post('/found', authentication, docValidation, lostItemsController.foundItem)
+  .get('/lost/all', authentication, lostItemsController.allLost)
+  .get('/found/all', authentication, lostItemsController.allFound)
 
 export default lostRouter;


### PR DESCRIPTION
### What does this PR do?

- Allow users to send request to read all lost or found documents in database

### Description of task to be completed?

- To create a route to allow users to send request to view all lost or found items in DB

### How should this be manually tested?

- Clone repo `git clone` 

- Then checkout branch `git checkout ft-enable-read-items-#174038985`

- Then run `npm install` to install all dependencies

- After run `npm run dev` to start server

- When server start and connected to DB, head to postman and send a `get request` to `http://localhost:3000/api/v1/items/lost/all` to get all lost docs and then send another request to `http://localhost:3000/api/v1/items/found/all` to get all found docs.

### Any background context you want to provide?

- To be able to send a request you should be authenticated in order to send request. To do so, you need to signup, if you signed up yet, login and provide token in header as key `auth-token` and value as `token value`

### What are the relevant pivotal tracker stories?
#174038985

